### PR TITLE
Confetti Easter Egg When Pressing Jump to Nearest Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.3",
         "astro": "^5.16.0",
+        "canvas-confetti": "^1.9.2",
         "dayjs": "^1.11.19",
         "isomorphic-dompurify": "^2.30.0",
         "marked": "^16.4.1",
@@ -26,7 +27,8 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.2.6"
+        "@biomejs/biome": "^2.2.6",
+        "@types/canvas-confetti": "^1.6.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3096,6 +3098,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3949,6 +3958,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "dayjs": "^1.11.19",
     "isomorphic-dompurify": "^2.30.0",
     "marked": "^16.4.1",
+    "canvas-confetti": "^1.9.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.6"
+    "@biomejs/biome": "^2.2.6",
+    "@types/canvas-confetti": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.6",
-    "@types/canvas-confetti": "^1.6.1"
+    "@types/canvas-confetti": "^1.9.0"
   }
 }

--- a/src/components/DueDate.astro
+++ b/src/components/DueDate.astro
@@ -1,8 +1,8 @@
 ---
 import {
-  localizeTime,
-  formatTime,
   calculateAbsoluteDate,
+  formatTime,
+  localizeTime,
 } from "../utils/dateUtils";
 
 interface Props {

--- a/src/components/EnhancedMarkdownContent.astro
+++ b/src/components/EnhancedMarkdownContent.astro
@@ -1,6 +1,6 @@
 ---
-import Default from "@astrojs/starlight/components/MarkdownContent.astro";
 import { Aside } from "@astrojs/starlight/components";
+import Default from "@astrojs/starlight/components/MarkdownContent.astro";
 
 const { data } = Astro.locals.starlightRoute.entry;
 ---

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -107,7 +107,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
 // class concludes on the Friday of finals week
 
 const concluded = calculateAbsoluteDate({
-  week: 16,
+  week: 15,
   day: "Friday",
   time: "17:00:00",
 }).isBefore(dayjs());
@@ -272,6 +272,11 @@ const concluded = calculateAbsoluteDate({
       background: var(--sl-color-text-accent);
       color: var(--sl-color-black);
     }
+    .action[aria-disabled="true"] {
+      pointer-events: none;
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
     ul {
       padding-left: 0.5rem;
     }
@@ -320,6 +325,55 @@ const concluded = calculateAbsoluteDate({
       (toast as any)._hideTimer = window.setTimeout(() => {
         toast!.style.opacity = "0";
       }, duration);
+    };
+
+    // Simple confetti effect across the screen for a short duration
+    const launchConfetti = () => {
+      const duration = 2500;
+      const endTime = Date.now() + duration;
+      const colors = ["#f94144", "#f3722c", "#f9c74f", "#90be6d", "#43aa8b", "#577590"];
+
+      const createPiece = () => {
+        const piece = document.createElement("div");
+        const size = Math.random() * 8 + 6; // 6px - 14px
+        piece.style.position = "fixed";
+        piece.style.top = "-20px";
+        piece.style.left = Math.random() * 100 + "vw";
+        piece.style.width = size + "px";
+        piece.style.height = size * 0.6 + "px";
+        piece.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
+        piece.style.transform = `rotate(${Math.random() * 360}deg)`;
+        piece.style.opacity = "0.9";
+        piece.style.zIndex = "9999";
+        piece.style.borderRadius = "2px";
+        piece.style.willChange = "transform, top, left, opacity";
+        document.body.appendChild(piece);
+
+        const fallDuration = Math.random() * 1500 + 1500; // 1.5s - 3s
+        const horizontalDrift = (Math.random() - 0.5) * 40; // -20px to 20px
+        const spin = (Math.random() - 0.5) * 720; // -360deg to 360deg
+
+        const start = performance.now();
+        const animate = (now: number) => {
+          const t = Math.min(1, (now - start) / fallDuration);
+          piece.style.top = `${t * 100}vh`;
+          piece.style.left = `calc(${piece.style.left} + ${t * horizontalDrift}px)`;
+          piece.style.transform = `rotate(${t * spin}deg)`;
+          piece.style.opacity = `${1 - t}`;
+
+          if (t < 1) {
+            requestAnimationFrame(animate);
+          } else {
+            piece.remove();
+          }
+        };
+        requestAnimationFrame(animate);
+      };
+
+      const interval = setInterval(() => {
+        for (let i = 0; i < 12; i++) createPiece();
+        if (Date.now() > endTime) clearInterval(interval);
+      }, 200);
     };
 
     // function to jump to the nearest date, button and functionality is set here
@@ -469,10 +523,18 @@ const concluded = calculateAbsoluteDate({
     document
       .querySelector("#jumpToDateButton")
       ?.addEventListener("click", () => {
-        const btn = document.querySelector("#jumpToDateButton");
+        const btn = document.querySelector("#jumpToDateButton") as HTMLElement | null;
         const isConcluded = btn?.getAttribute("data-concluded") === "true";
         if (isConcluded) {
-          showToast("This course has concluded. There are no upcoming dates to jump to.");
+          // Trigger celebratory confetti
+          launchConfetti();
+
+          // Replace button text and disable further interaction
+          if (btn) {
+            btn.textContent = "Course Concluded!";
+            btn.setAttribute("aria-disabled", "true");
+            btn.setAttribute("title", "Course Concluded!");
+          }
           return;
         }
 

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -296,10 +296,10 @@ const events = [...exams, ...homeworks, ...lectures].sort(
     const isDesktop = window.innerWidth >= 1024;
     
     // events is already sorted, so just check if the last event is in the past
-    // class concludes on the Friday after finals week
+    // class concludes on the Friday before finals week
     
     const courseIsConcluded = calculateAbsoluteDate({
-      week: 16,
+      week: 15,
       day: "Friday",
       time: "17:00:00",
     }).isBefore(dayjs());

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -296,7 +296,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
     const getIsDesktop = () => window.innerWidth >= 1024;
     
     // events is already sorted, so just check if the last event is in the past
-    // class concludes on the Friday before finals week
+    // class concludes on the Friday of week 15 (the last week of instruction)
     
     const courseIsConcluded = calculateAbsoluteDate({
       week: 15,

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -310,6 +310,9 @@ const events = [...exams, ...homeworks, ...lectures].sort(
       if (!toast) {
         toast = document.createElement("div");
         toast.id = "schedule-toast";
+        toast.setAttribute("role", "alert");
+        toast.setAttribute("aria-live", "assertive");
+        toast.setAttribute("aria-atomic", "true");
         toast.style.position = "fixed";
         toast.style.bottom = "20px";
         if (!getIsDesktop()) {

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -293,7 +293,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
     import dayjs from "dayjs";
     import { calculateAbsoluteDate } from "../utils/dateUtils";
     
-    const isDesktop = window.innerWidth >= 1024;
+    const getIsDesktop = () => window.innerWidth >= 1024;
     
     // events is already sorted, so just check if the last event is in the past
     // class concludes on the Friday before finals week
@@ -312,7 +312,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
         toast.id = "schedule-toast";
         toast.style.position = "fixed";
         toast.style.bottom = "20px";
-        if (!isDesktop) {
+        if (!getIsDesktop()) {
           toast.style.left = "12px";
           toast.style.right = "12px";
           toast.style.transform = "";
@@ -323,7 +323,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
           toast.style.left = "";
           toast.style.transform = "";
         }
-        toast.style.maxWidth = isDesktop ? "320px" : "none";
+        toast.style.maxWidth = getIsDesktop() ? "320px" : "none";
         toast.style.padding = "12px 16px";
         toast.style.borderRadius = "8px";
         toast.style.boxShadow = "0 4px 12px rgba(0,0,0,0.2)";
@@ -351,14 +351,14 @@ const events = [...exams, ...homeworks, ...lectures].sort(
         // Responsive side bursts with optional mid-screen burst on desktop
         const desktop = { particleCount: 360, spread: 200, startVelocity: 34, decay: 0.88, scalar: 1.05, gravity: 0.85, y: 0.30 };
         const mobile  = { particleCount: 170,  spread: 50,  startVelocity: 25, decay: 0.94, scalar: 0.85, gravity: 1.1, y: 0.7 };
-        const cfg = isDesktop ? desktop : mobile;
+        const cfg = getIsDesktop() ? desktop : mobile;
 
         // Side bursts (left and right)
         confetti({ ...cfg, angle: 60, origin: { x: -0.1, y: cfg.y } });
         confetti({ ...cfg, angle: 120, origin: { x: 1.1, y: cfg.y } });
 
         // Optional mid-screen burst to fill center, desktop only
-        if (isDesktop) {
+        if (getIsDesktop()) {
           setTimeout(() => {
             confetti({ particleCount: 140, angle: 90, origin: { x: 0.5, y: 1.0 }, spread: 120, startVelocity: 26, decay: 0.90, scalar: 1.0, gravity: 0.9 });
           }, 150);

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -104,18 +104,11 @@ const events = [...exams, ...homeworks, ...lectures].sort(
   (a, b) => a.date.valueOf() - b.date.valueOf(),
 );
 
-// events is already sorted, so just check if the last event is in the past
-// class concludes on the Friday of finals week
 
-const concluded = calculateAbsoluteDate({
-  week: 16,
-  day: "Friday",
-  time: "17:00:00",
-}).isBefore(dayjs());
 ---
 
 <div class="controls-container">
-  <span class="action primary" id="jumpToDateButton" data-concluded={concluded}>
+  <span class="action primary" id="jumpToDateButton">
     Jump to Nearest Date
   </span>
 
@@ -298,6 +291,16 @@ const concluded = calculateAbsoluteDate({
 
   <script>
     import dayjs from "dayjs";
+    import { calculateAbsoluteDate } from "../utils/dateUtils";
+    
+    // events is already sorted, so just check if the last event is in the past
+    // class concludes on the Friday after finals week
+    
+    const courseIsConcluded = calculateAbsoluteDate({
+      week: 16,
+      day: "Friday",
+      time: "17:00:00",
+    }).isBefore(dayjs());
 
     // Lightweight toast helper reused across interactions
     const showToast = (message: string, duration = 3000) => {
@@ -505,8 +508,7 @@ const concluded = calculateAbsoluteDate({
       .querySelector("#jumpToDateButton")
       ?.addEventListener("click", () => {
         const btn = document.querySelector("#jumpToDateButton") as HTMLElement | null;
-        const isConcluded = btn?.getAttribute("data-concluded") === "true";
-        if (isConcluded) {
+        if (courseIsConcluded) {
           // Trigger celebratory confetti
           launchConfetti();
 

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -108,8 +108,8 @@ const events = [...exams, ...homeworks, ...lectures].sort(
 ---
 
 <div class="controls-container">
-  <span class="action primary" id="jumpToDateButton">
-    Jump to Nearest Date
+  <span class="action primary" id="jumpToNextEvent">
+    Jump to Next Event
   </span>
 
   <!-- Filter Buttons -->
@@ -371,8 +371,8 @@ const events = [...exams, ...homeworks, ...lectures].sort(
       }
     };
 
-    // function to jump to the nearest date, button and functionality is set here
-    const jumpToDate = () => {
+    // function to jump to the next event after today, button and functionality is set here
+    const jumpToNextEvent = () => {
       const today = dayjs();
       const rows = document.querySelectorAll("tr[data-date]:not([hidden])");
       const nearestRow = Array.from(rows)
@@ -516,9 +516,9 @@ const events = [...exams, ...homeworks, ...lectures].sort(
     });
 
     document
-      .querySelector("#jumpToDateButton")
+      .querySelector("#jumpToNextEvent")
       ?.addEventListener("click", () => {
-        const btn = document.querySelector("#jumpToDateButton") as HTMLElement | null;
+        const btn = document.querySelector("#jumpToNextEvent") as HTMLElement | null;
         if (courseIsConcluded) {
           // Trigger celebratory confetti
           launchConfetti();
@@ -547,7 +547,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
           return;
         }
 
-        jumpToDate();
+        jumpToNextEvent();
       });
   </script>
 </div>

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -1,11 +1,11 @@
 ---
 import { getCollection } from "astro:content";
-import { marked } from "marked";
-import DOMPurify from "isomorphic-dompurify";
-import dayjs, { type Dayjs } from "dayjs";
-import { formatTime, calculateAbsoluteDate } from "../utils/dateUtils";
 import { Badge } from "@astrojs/starlight/components";
+import dayjs, { type Dayjs } from "dayjs";
+import DOMPurify from "isomorphic-dompurify";
+import { marked } from "marked";
 import { transformContentData } from "../utils/contentUtils";
+import { calculateAbsoluteDate, formatTime } from "../utils/dateUtils";
 
 interface Reading {
   link: string;

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -113,21 +113,17 @@ const concluded = calculateAbsoluteDate({
 }).isBefore(dayjs());
 ---
 
-{
-  !concluded && (
-    <div class="controls-container">
-      <span class="action primary" id="jumpToDateButton">
-        Jump to Nearest Date
-      </span>
-      
-      <!-- Filter Buttons -->
-      <span class="action primary filter-button" id="filterAll" data-filter="all">All</span>
-      <span class="action secondary filter-button" id="filterLecture" data-filter="lecture">Lectures</span>
-      <span class="action secondary filter-button" id="filterHomework" data-filter="homework">Homeworks</span>
-      <span class="action secondary filter-button" id="filterExam" data-filter="exam">Exams</span>
-    </div>
-  )
-}
+<div class="controls-container">
+  <span class="action primary" id="jumpToDateButton" data-concluded={concluded}>
+    Jump to Nearest Date
+  </span>
+
+  <!-- Filter Buttons -->
+  <span class="action primary filter-button" id="filterAll" data-filter="all">All</span>
+  <span class="action secondary filter-button" id="filterLecture" data-filter="lecture">Lectures</span>
+  <span class="action secondary filter-button" id="filterHomework" data-filter="homework">Homeworks</span>
+  <span class="action secondary filter-button" id="filterExam" data-filter="exam">Exams</span>
+</div>
 
 <div class="not-content ml-4 flex items-center lg:ml-0 lg:justify-center">
   <table class="border-separate border-spacing-y-2 text-sm">
@@ -297,6 +293,35 @@ const concluded = calculateAbsoluteDate({
   <script>
     import dayjs from "dayjs";
 
+    // Lightweight toast helper reused across interactions
+    const showToast = (message: string, duration = 3000) => {
+      let toast = document.getElementById("schedule-toast");
+      if (!toast) {
+        toast = document.createElement("div");
+        toast.id = "schedule-toast";
+        toast.style.position = "fixed";
+        toast.style.bottom = "20px";
+        toast.style.right = "20px";
+        toast.style.maxWidth = "320px";
+        toast.style.padding = "12px 16px";
+        toast.style.borderRadius = "8px";
+        toast.style.boxShadow = "0 4px 12px rgba(0,0,0,0.2)";
+        toast.style.backgroundColor = "var(--sl-color-accent-low)";
+        toast.style.color = "var(--sl-color-text)";
+        toast.style.fontSize = "14px";
+        toast.style.zIndex = "9999";
+        toast.style.opacity = "0";
+        toast.style.transition = "opacity 200ms ease";
+        document.body.appendChild(toast);
+      }
+      toast.textContent = message;
+      toast.style.opacity = "1";
+      window.clearTimeout((toast as any)._hideTimer);
+      (toast as any)._hideTimer = window.setTimeout(() => {
+        toast!.style.opacity = "0";
+      }, duration);
+    };
+
     // function to jump to the nearest date, button and functionality is set here
     const jumpToDate = () => {
       const today = dayjs();
@@ -369,7 +394,7 @@ const concluded = calculateAbsoluteDate({
       buttons.forEach((button) => {
         const filterType = button.getAttribute('data-filter');
         const isActive = filterType === activeFilter;
-        
+
         // Update the class for styling
         if (isActive) {
           button.classList.remove('secondary');
@@ -388,13 +413,13 @@ const concluded = calculateAbsoluteDate({
         const show = filterType === "all" || type === filterType;
         (row as HTMLElement).hidden = !show;
       });
-      
+
       // Update zebra striping after filtering
       updateZebraStriping();
-      
+
       // Update button variants
       updateLinkButtonVariants(filterType);
-      
+
       // Update URL without triggering page reload
       const newHash = filterToHash[filterType] || '#all';
       if (window.location.hash !== newHash) {
@@ -444,6 +469,28 @@ const concluded = calculateAbsoluteDate({
     document
       .querySelector("#jumpToDateButton")
       ?.addEventListener("click", () => {
+        const btn = document.querySelector("#jumpToDateButton");
+        const isConcluded = btn?.getAttribute("data-concluded") === "true";
+        if (isConcluded) {
+          showToast("This course has concluded. There are no upcoming dates to jump to.");
+          return;
+        }
+
+        // If there are no upcoming visible events (same day or future), show a toast and bail
+        const now = dayjs();
+        const upcomingVisibleRows = Array.from(
+          document.querySelectorAll("tr[data-date]:not([hidden])")
+        ).filter((row) => {
+          const rowDateStr = row.getAttribute("data-date") || "";
+          const rowDate = dayjs(rowDateStr);
+          return rowDate.isSame(now, "day") || rowDate.isAfter(now, "day");
+        });
+
+        if (upcomingVisibleRows.length === 0) {
+          showToast("No upcoming events are visible in the current view.");
+          return;
+        }
+
         jumpToDate();
       });
   </script>

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -7,6 +7,7 @@ import { marked } from "marked";
 import { transformContentData } from "../utils/contentUtils";
 import { calculateAbsoluteDate, formatTime } from "../utils/dateUtils";
 
+
 interface Reading {
   link: string;
   name: string;
@@ -107,7 +108,7 @@ const events = [...exams, ...homeworks, ...lectures].sort(
 // class concludes on the Friday of finals week
 
 const concluded = calculateAbsoluteDate({
-  week: 15,
+  week: 16,
   day: "Friday",
   time: "17:00:00",
 }).isBefore(dayjs());
@@ -327,53 +328,33 @@ const concluded = calculateAbsoluteDate({
       }, duration);
     };
 
-    // Simple confetti effect across the screen for a short duration
-    const launchConfetti = () => {
-      const duration = 2500;
-      const endTime = Date.now() + duration;
-      const colors = ["#f94144", "#f3722c", "#f9c74f", "#90be6d", "#43aa8b", "#577590"];
+    // Confetti effect using dynamically imported canvas-confetti (bundled)
+    const launchConfetti = async () => {
+      try {
+        const { default: confetti } = await import("canvas-confetti");
 
-      const createPiece = () => {
-        const piece = document.createElement("div");
-        const size = Math.random() * 8 + 6; // 6px - 14px
-        piece.style.position = "fixed";
-        piece.style.top = "-20px";
-        piece.style.left = Math.random() * 100 + "vw";
-        piece.style.width = size + "px";
-        piece.style.height = size * 0.6 + "px";
-        piece.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
-        piece.style.transform = `rotate(${Math.random() * 360}deg)`;
-        piece.style.opacity = "0.9";
-        piece.style.zIndex = "9999";
-        piece.style.borderRadius = "2px";
-        piece.style.willChange = "transform, top, left, opacity";
-        document.body.appendChild(piece);
+        // Responsive side bursts with optional mid-screen burst on desktop
+        const isDesktop = window.innerWidth >= 1024;
+        const desktop = { particleCount: 360, spread: 200, startVelocity: 34, decay: 0.88, scalar: 1.05, gravity: 0.85, y: 0.30 };
+        const mobile  = { particleCount: 170,  spread: 50,  startVelocity: 25, decay: 0.94, scalar: 0.85, gravity: 1.1, y: 0.7 };
+        const cfg = isDesktop ? desktop : mobile;
 
-        const fallDuration = Math.random() * 1500 + 1500; // 1.5s - 3s
-        const horizontalDrift = (Math.random() - 0.5) * 40; // -20px to 20px
-        const spin = (Math.random() - 0.5) * 720; // -360deg to 360deg
+        // Side bursts (left and right)
+        confetti({ particleCount: cfg.particleCount, angle: 60, origin: { x: -0.1, y: cfg.y }, spread: cfg.spread, startVelocity: cfg.startVelocity, decay: cfg.decay, scalar: cfg.scalar, gravity: cfg.gravity });
+        confetti({ particleCount: cfg.particleCount, angle: 120, origin: { x: 1.1, y: cfg.y }, spread: cfg.spread, startVelocity: cfg.startVelocity, decay: cfg.decay, scalar: cfg.scalar, gravity: cfg.gravity });
 
-        const start = performance.now();
-        const animate = (now: number) => {
-          const t = Math.min(1, (now - start) / fallDuration);
-          piece.style.top = `${t * 100}vh`;
-          piece.style.left = `calc(${piece.style.left} + ${t * horizontalDrift}px)`;
-          piece.style.transform = `rotate(${t * spin}deg)`;
-          piece.style.opacity = `${1 - t}`;
+        // Optional mid-screen burst to fill center, desktop only
+        if (isDesktop) {
+          setTimeout(() => {
+            confetti({ particleCount: 140, angle: 90, origin: { x: 0.5, y: 1.0 }, spread: 120, startVelocity: 26, decay: 0.90, scalar: 1.0, gravity: 0.9 });
+          }, 150);
+        }
 
-          if (t < 1) {
-            requestAnimationFrame(animate);
-          } else {
-            piece.remove();
-          }
-        };
-        requestAnimationFrame(animate);
-      };
-
-      const interval = setInterval(() => {
-        for (let i = 0; i < 12; i++) createPiece();
-        if (Date.now() > endTime) clearInterval(interval);
-      }, 200);
+        // Falling effect is handled by these bursts; no repeated interval.
+      } catch (e) {
+        // Fallback: log and continue without confetti
+        console.warn("Confetti unavailable:", e);
+      }
     };
 
     // function to jump to the nearest date, button and functionality is set here

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -354,8 +354,8 @@ const events = [...exams, ...homeworks, ...lectures].sort(
         const cfg = isDesktop ? desktop : mobile;
 
         // Side bursts (left and right)
-        confetti({ particleCount: cfg.particleCount, angle: 60, origin: { x: -0.1, y: cfg.y }, spread: cfg.spread, startVelocity: cfg.startVelocity, decay: cfg.decay, scalar: cfg.scalar, gravity: cfg.gravity });
-        confetti({ particleCount: cfg.particleCount, angle: 120, origin: { x: 1.1, y: cfg.y }, spread: cfg.spread, startVelocity: cfg.startVelocity, decay: cfg.decay, scalar: cfg.scalar, gravity: cfg.gravity });
+        confetti({ ...cfg, angle: 60, origin: { x: -0.1, y: cfg.y } });
+        confetti({ ...cfg, angle: 120, origin: { x: 1.1, y: cfg.y } });
 
         // Optional mid-screen burst to fill center, desktop only
         if (isDesktop) {

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -293,6 +293,8 @@ const events = [...exams, ...homeworks, ...lectures].sort(
     import dayjs from "dayjs";
     import { calculateAbsoluteDate } from "../utils/dateUtils";
     
+    const isDesktop = window.innerWidth >= 1024;
+    
     // events is already sorted, so just check if the last event is in the past
     // class concludes on the Friday after finals week
     
@@ -310,8 +312,18 @@ const events = [...exams, ...homeworks, ...lectures].sort(
         toast.id = "schedule-toast";
         toast.style.position = "fixed";
         toast.style.bottom = "20px";
-        toast.style.right = "20px";
-        toast.style.maxWidth = "320px";
+        if (!isDesktop) {
+          toast.style.left = "12px";
+          toast.style.right = "12px";
+          toast.style.transform = "";
+          toast.style.width = "auto";
+          toast.style.maxWidth = "none";
+        } else {
+          toast.style.right = "20px";
+          toast.style.left = "";
+          toast.style.transform = "";
+        }
+        toast.style.maxWidth = isDesktop ? "320px" : "none";
         toast.style.padding = "12px 16px";
         toast.style.borderRadius = "8px";
         toast.style.boxShadow = "0 4px 12px rgba(0,0,0,0.2)";
@@ -337,7 +349,6 @@ const events = [...exams, ...homeworks, ...lectures].sort(
         const { default: confetti } = await import("canvas-confetti");
 
         // Responsive side bursts with optional mid-screen burst on desktop
-        const isDesktop = window.innerWidth >= 1024;
         const desktop = { particleCount: 360, spread: 200, startVelocity: 34, decay: 0.88, scalar: 1.05, gravity: 0.85, y: 0.30 };
         const mobile  = { particleCount: 170,  spread: 50,  startVelocity: 25, decay: 0.94, scalar: 0.85, gravity: 1.1, y: 0.7 };
         const cfg = isDesktop ? desktop : mobile;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection, z } from "astro:content";
-import { docsSchema } from "@astrojs/starlight/schema";
 import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
 import { glob } from "astro/loaders";
 
 // Relative date schema that can be reused

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,6 +1,6 @@
-import { calculateAbsoluteDate } from "./dateUtils";
-import type { ContentData } from "../types/content";
 import { courseConfig } from "../courseConfig";
+import type { ContentData } from "../types/content";
+import { calculateAbsoluteDate } from "./dateUtils";
 
 /**
  * Transforms content data by converting relative dates to absolute dates


### PR DESCRIPTION
Much of this was vibe coded, but I'm pretty confident in its correctness. I certainly tested it and understand the code it added.
- Renamed "Jump to Nearest Date" to "Jump to Next Event"
  - This more directly reflects the thing it does... though it still doesn't quite reflect the fact it'll jump to the current day's event, after that event, even after the event ends (which is behavior I want to retain). I'm totally open to suggestions.
- Restores the filter buttons even after the course has ended.
- Made the "Jump to Next Event" button play a short confetti animation if pressed after the course ended.
- Display an error message in a toast if the user presses "Jump to Next Event" and there are no next events, but the course hasn't ended. Begone, silent failure! Begone!
- Made the course end after week 15 instead of week 16.
  - This is just my preference, and it's currently the most recent commit (commit f0fbd13d642b5518425a6c232656ee7a04306873), so it should be super easy to undo.